### PR TITLE
Fix reply bug

### DIFF
--- a/Pio/ComposerViewController.swift
+++ b/Pio/ComposerViewController.swift
@@ -100,7 +100,7 @@ class ComposerViewController: UIViewController, UITextViewDelegate {
             let progress = showProgressDialog(attachedTo: topView, message: "Posting tweet ...")
             let newTweet = replyTweetPrefix + compositionField.text.trim()
             TwitterService.sharedInstance.postUpdate(newTweet,
-                replyTo: tweetToReply?.user.screenName,
+                replyTo: tweetToReply?.id,
                 onSuccess: { (tweet) -> Void in
                     progress.hide(true)
                     self.newTweetPostedCallback?.onNewTweetPosted(tweet)

--- a/Pio/TwitterService.swift
+++ b/Pio/TwitterService.swift
@@ -121,9 +121,9 @@ class TwitterService {
         return loadTimeline(params, onSuccess: onSuccess, onFailure: onFailure)
     }
     
-    func postUpdate(status: String, replyTo: String? = nil, onSuccess: (Tweet) -> Void, onFailure: () -> Void = {}) -> NetTask {
+    func postUpdate(status: String, replyTo: Int64? = nil, onSuccess: (Tweet) -> Void, onFailure: () -> Void = {}) -> NetTask {
         return session.POST("1.1/statuses/update.json",
-            parameters: ["status": status.truncate(140), "in_reply_to_status_id": replyTo ?? ""],
+            parameters: ["status": status.truncate(140), "in_reply_to_status_id": replyTo != nil ? String(replyTo!): ""],
             success: { (_, response) -> Void in
                 do {
                     let json = JSON(response)


### PR DESCRIPTION
I was sending  the screen name instead of the tweet's id  in the parameter `in_reply_to_status_id`  to `POST statuses/update` . Didn't notice the problem before because app updates the UI correctly (it displays a "replied to @screen_name". Only notice the bug after submission when checking my timeline and noticing that link with original tweet was not established.
